### PR TITLE
Tweaks & fixes from user feedback

### DIFF
--- a/appPy/src/TD/vapor_models/wagner.py
+++ b/appPy/src/TD/vapor_models/wagner.py
@@ -20,7 +20,7 @@ def wagner_fun(T, A, B, C, D, p_c, T_c):
 wagner_model = Vapor_Model(name='Wagner',
                            fun=wagner_fun,
                            n_params=6,
-                           params0=np.array([-8, 1, -1, -1, 5e3, 600]),
+                           params0=np.array([-8, 1, -1, -1, 1e4, 1e3]),
                            param_names=['A', 'B', 'C', 'D', 'p_c', 'T_c'],
                            param_labels=['A', 'B', 'C', 'D', 'p_c / kPa', 'T_c / K'],
                            always_const_param_names=['p_c', 'T_c'])

--- a/appPy/src/plot/Fredenslund_plot.py
+++ b/appPy/src/plot/Fredenslund_plot.py
@@ -26,6 +26,7 @@ class Fredenslund_plot(Fredenslund_test):
         plt.title(f'{self.get_title()}\n$p$ residuals')
         plt.xlim(0, 1)
         plt.xlabel('$x_1$')
+        plt.ylabel('$\\delta p$')
 
         return finish_plot(mode)
 
@@ -38,6 +39,7 @@ class Fredenslund_plot(Fredenslund_test):
         plt.title(f'{self.get_title()}\n$y$ residuals')
         plt.xlim(0, 1)
         plt.xlabel('$x_1$')
+        plt.ylabel('$\\Delta y$')
         plt.legend()
 
         return finish_plot(mode)

--- a/appUI/src/actions/VaporAnalysis/VaporAnalysisDialog.tsx
+++ b/appUI/src/actions/VaporAnalysis/VaporAnalysisDialog.tsx
@@ -9,7 +9,7 @@ import { DialogTitleWithX } from '../../components/Mui/DialogTitle.tsx';
 import { DialogProps } from '../../adapters/types/DialogProps.ts';
 import { PlotWithDownload } from '../../components/charts/PlotWithDownload.tsx';
 import { AnalysisWarnings } from '../../components/AnalysisResults/AnalysisWarnings.tsx';
-import { toSigDgts } from '../../adapters/logic/numbers.ts';
+import { sanitizeNumStr, toSigDgts } from '../../adapters/logic/numbers.ts';
 
 type SubmitHandler = (e: FormEvent<HTMLFormElement>) => void;
 
@@ -25,7 +25,7 @@ export const VaporAnalysisDialog: FC<VaporAnalysisDialogProps> = ({ data, open, 
     const handleQuery_T = useCallback<SubmitHandler>(
         async (e) => {
             e.preventDefault();
-            const T = input_T(parseFloat(query_T), UoM_T);
+            const T = input_T(parseFloat(sanitizeNumStr(query_T)), UoM_T);
             if (isNaN(T)) return;
             const { p } = await mutateAsync({ compound: data.compound, T });
             setQuery_p(toSigDgts(display_p(p, UoM_p), 4));
@@ -35,7 +35,7 @@ export const VaporAnalysisDialog: FC<VaporAnalysisDialogProps> = ({ data, open, 
     const handleQuery_p = useCallback<SubmitHandler>(
         async (e) => {
             e.preventDefault();
-            const p = input_p(parseFloat(query_p), UoM_p);
+            const p = input_p(parseFloat(sanitizeNumStr(query_p)), UoM_p);
             if (isNaN(p)) return;
             const { T } = await mutateAsync({ compound: data.compound, p });
             setQuery_T(toSigDgts(display_T(T, UoM_T)));

--- a/appUI/src/adapters/io/filenames.ts
+++ b/appUI/src/adapters/io/filenames.ts
@@ -1,0 +1,2 @@
+export const fileNameRegex = /^[a-zA-Z0-9\-_,. ]+$/;
+export const fileNameMaxLength = 50;

--- a/appUI/src/adapters/useIsInstanceLocked.ts
+++ b/appUI/src/adapters/useIsInstanceLocked.ts
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 
 export const useIsInstanceLocked = () => {
-    const [isInstanceLocked, setIsInstanceLocked] = useState(false);
+    const [isInstanceLocked, setIsInstanceLocked] = useState(true);
 
     useEffect(() => {
         window.electron.getInstanceLock().then(setIsInstanceLocked);

--- a/appUI/src/pages/Compounds/UpsertCompoundDialog.tsx
+++ b/appUI/src/pages/Compounds/UpsertCompoundDialog.tsx
@@ -38,7 +38,7 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
     const { compoundNames, vaporDefs, findCompound } = useData();
     const [compound, setCompound] = useState(origCompound ?? '');
     const getOrigModel = () => findCompound(origCompound ?? '');
-    const [T_min, setT_min] = useState(() => getOrigModel()?.T_min ?? 99);
+    const [T_min, setT_min] = useState(() => getOrigModel()?.T_min ?? 199);
     const [T_max, setT_max] = useState(() => getOrigModel()?.T_max ?? 999);
     const [model, setModel] = useState(() => getOrigModel()?.model_name ?? '');
 
@@ -47,13 +47,6 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
     const modelDef = useMemo(() => findModelDef(model), [model]);
     const paramNames = useMemo(() => fromNamedParams(modelDef?.nparams0)[0], [modelDef]);
     const columnLabels = useMemo(() => fromNamedParams(modelDef?.param_labels)[1], [modelDef]);
-
-    // CHECKS
-    const isEdit = Boolean(origCompound);
-    const isCompoundChanged = isEdit && origCompound !== compound;
-    const willReplace = origCompound !== compound && compoundNames.includes(compound);
-    const tempError = T_min >= T_max || isNaN(T_min) || isNaN(T_max);
-    const isNameValid = fileNameRegex.test(compound) && compound.length <= fileNameMaxLength;
 
     // ACTIONS
     const restoreOrig = () => origCompound && setCompound(origCompound);
@@ -102,8 +95,16 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
         setForceUpdateVersion((prev) => prev + 1);
     }, []);
 
+    // CHECKS
+    const isEdit = Boolean(origCompound);
+    const isCompoundChanged = isEdit && origCompound !== compound;
+    const willReplace = origCompound !== compound && compoundNames.includes(compound);
+    const tempError = T_min >= T_max || isNaN(T_min) || isNaN(T_max);
+    const antoineCError = model.includes('Antoine') && T_min + numData[2] <= 0;
+    const isNameValid = fileNameRegex.test(compound) && compound.length <= fileNameMaxLength;
+
     // OVERALL ERROR CHECK
-    const isError = !compound || !model || tempError || !isDataWhole || !isNameValid;
+    const isError = !compound || !model || tempError || !isDataWhole || !isNameValid || antoineCError;
 
     return (
         <>
@@ -176,6 +177,7 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
                                 </Stack>
                             </Box>
                         )}
+                        {antoineCError && <ErrorLabel title="For Antoine, min temp must be greater than -C" />}
                         {modelDef && (
                             <Box mt={3}>
                                 <h4>Model parameters</h4>

--- a/appUI/src/pages/Compounds/UpsertCompoundDialog.tsx
+++ b/appUI/src/pages/Compounds/UpsertCompoundDialog.tsx
@@ -22,6 +22,7 @@ import {
     toNumMatrix,
 } from '../../adapters/logic/spreadsheet.ts';
 import { fromNamedParams, toNamedParams } from '../../adapters/logic/nparams.ts';
+import { fileNameMaxLength, fileNameRegex } from '../../adapters/io/filenames.ts';
 import { useNotifications } from '../../contexts/NotificationContext.tsx';
 import { DialogTitleWithX } from '../../components/Mui/DialogTitle.tsx';
 import { ErrorLabel, InfoLabel, WarningLabel } from '../../components/dataViews/TooltipIcons.tsx';
@@ -37,8 +38,8 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
     const { compoundNames, vaporDefs, findCompound } = useData();
     const [compound, setCompound] = useState(origCompound ?? '');
     const getOrigModel = () => findCompound(origCompound ?? '');
-    const [T_min, setT_min] = useState(() => getOrigModel()?.T_min ?? 0);
-    const [T_max, setT_max] = useState(() => getOrigModel()?.T_max ?? 1000);
+    const [T_min, setT_min] = useState(() => getOrigModel()?.T_min ?? 99);
+    const [T_max, setT_max] = useState(() => getOrigModel()?.T_max ?? 999);
     const [model, setModel] = useState(() => getOrigModel()?.model_name ?? '');
 
     const findModelDef = (modelName: string) => vaporDefs!.find((vd) => vd.name === modelName);
@@ -52,6 +53,7 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
     const isCompoundChanged = isEdit && origCompound !== compound;
     const willReplace = origCompound !== compound && compoundNames.includes(compound);
     const tempError = T_min >= T_max || isNaN(T_min) || isNaN(T_max);
+    const isNameValid = fileNameRegex.test(compound) && compound.length <= fileNameMaxLength;
 
     // ACTIONS
     const restoreOrig = () => origCompound && setCompound(origCompound);
@@ -101,7 +103,7 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
     }, []);
 
     // OVERALL ERROR CHECK
-    const isError = !compound || tempError || !isDataWhole;
+    const isError = !compound || !model || tempError || !isDataWhole || !isNameValid;
 
     return (
         <>
@@ -127,6 +129,7 @@ export const UpsertCompoundDialog: FC<UpsertCompoundDialogProps> = ({ origCompou
                                 </div>
                             )}
                             {willReplace && <WarningLabel title="This will overwrite existing compound." />}
+                            {compound && !isNameValid && <ErrorLabel title="Name invalid or too long." />}
                         </Stack>
                         <FormControl fullWidth>
                             <InputLabel id="model">Model type</InputLabel>

--- a/appUI/src/pages/Settings.tsx
+++ b/appUI/src/pages/Settings.tsx
@@ -212,12 +212,12 @@ export const Settings: FC = () => {
                 <h2>Settings</h2>
             </HeaderStack>
             <Tabs value={tab} onChange={(_e, newValue) => setTab(newValue)}>
-                <Tab label="Calculations" />
                 <Tab label="UI & Charts" />
+                <Tab label="Calculations" />
             </Tabs>
             <form onSubmit={handleSubmit}>
-                {tab === 0 && <CalcSettings formConfig={formConfig} patchConfig={patchConfig} send={send} />}
-                {tab === 1 && <UISettings formConfig={formConfig} patchConfig={patchConfig} send={send} />}
+                {tab === 0 && <UISettings formConfig={formConfig} patchConfig={patchConfig} send={send} />}
+                {tab === 1 && <CalcSettings formConfig={formConfig} patchConfig={patchConfig} send={send} />}
                 <Button type="submit" variant="contained" style={{ width: 'fit-content' }} sx={{ mt: 6 }}>
                     Save settings
                 </Button>

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -20,7 +20,8 @@ Following units of measurement are used in calculations, unless explicitly state
 - pressure: `kPa` _(in logarithmic form as well)_
 - temperature: `K`
 
-In UI, units are converted to user's preference as per config, but only the final values for display, not inputs. 
+In UI, units are converted to user's preference as per config for: 1) result values to be displayed, 2) from user inputs fields.  
+Notably, raw tabular data and model parameters are **not** converted (using standard units). 
 
 ### Styles
 Visual language of charts is following: **black** is main data series, **green** is calculated model.  

--- a/docs/references.md
+++ b/docs/references.md
@@ -16,7 +16,8 @@ Following literature sources were used for creation of this software:
   - van Ness: [van Ness 1995](https://doi.org/10.1351/pac199567060859)
 - Thermodynamic models
   - NRTL: [Renon 1968](https://doi.org/10.1002/aic.690140124)
+  - UNIQUAC: [Abrams 1975](https://dx.doi.org/10.1002/aic.690210115)
   - van Laar, Margules: Perry's Chemical Engineers' Handbook 8th edition, 4th book
 - Dev data
-  - VLE for EtOH,H2O: [Voutsas 2011](https://doi.org/10.1016/j.fluid.2011.06.009)
-  - Wagner for EtOH,H2O: from [Aspen Plus v11](https://www.aspentech.com/products/engineering/aspen-plus)
+  - VLE for EtOH–H2O: [Voutsas 2011](https://doi.org/10.1016/j.fluid.2011.06.009), [Kamihama 2012](https://dx.doi.org/10.1021/je2008704)
+  - Wagner for EtOH, H2O: from [Aspen Plus v11](https://www.aspentech.com/products/engineering/aspen-plus)


### PR DESCRIPTION
Another batch of changes, this time from prerelase user feedback!

- Validate filenames inputs, fix ps defaults
- Antoine T_min & C warning
- swap Settings Tabs
- add y labels for Fredenslund
- Use sanitizeNumStr everywhere
- Fix flickering of 2nd instance warning
- Add literature citations, update docs
