### PR TITLE
Bump version 2025.3.0

### DIFF
--- a/appUI/package-lock.json
+++ b/appUI/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vlizard",
-  "version": "2025.2.0",
+  "version": "2025.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vlizard",
-      "version": "2025.2.0",
+      "version": "2025.3.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/appUI/package.json
+++ b/appUI/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/Lemonexe/VLizard",
   "description": "VLizard, a VLE wizard.",
   "private": true,
-  "version": "2025.2.0",
+  "version": "2025.3.0",
   "type": "module",
   "main": "dist-electron/main.js",
   "engines": {

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -7,7 +7,7 @@ Three targets are supported, but only `flatpak` is recommended and officially di
 
 ### Flatpak build
 
-Follow [general build instructions](../README.md#build).
+Follow [general build instructions](appUI.md#build).
 
 In order to build the flatpak installer, you may need to install: 
 ```


### PR DESCRIPTION
Release checklist:
- [x] create this PR by
  - [x] bumping version in `package.json`
  - [x] running `npm i` to have `package.lock` updated
- [x] build locally at this branch
  - [x] QA Windows build
  - [x] QA Linux build
- [x] prepare release notes
- [ ] merge this, and do the following in quick succession
  - _because after this, all VLizard copies will offer app update. It's not ideal, but whatever, VLizard has very few users._
- [ ] tag `master HEAD` as 2025.3
- [ ] create github release 2025.3
- [ ] update [zenodo](https://doi.org/10.5281/zenodo.13357210)
